### PR TITLE
removed git config --global from tests/test_cli.py

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -328,8 +328,8 @@ def test_diff_skip_git_dir(args, expected_exit_code, cruft_runner, cookiecutter_
     with (cookiecutter_dir / "pyproject.toml").open("w") as f:
         f.write(dedent(skip_section))
     # Alter the git repo.
-    run(["git", "config", "--global", "user.email", "user@test.com"], cwd=cookiecutter_dir)
-    run(["git", "config", "--global", "user.name", "testm"], cwd=cookiecutter_dir)
+    # run(["git", "config", "--global", "user.email", "user@test.com"], cwd=cookiecutter_dir)
+    # run(["git", "config", "--global", "user.name", "testm"], cwd=cookiecutter_dir)
     run(["git", "add", "--all"], cwd=cookiecutter_dir)
     run(["git", "commit", "-m", "2nd commit"], cwd=cookiecutter_dir)
     result = cruft_runner(["diff", "--project-dir", cookiecutter_dir.as_posix(), "--exit-code"])


### PR DESCRIPTION
This is https://github.com/juhuebner/cookiecutter-test/blob/with-git-from-hook/dir/hooks/post_gen_project.py for a **local** cocnf